### PR TITLE
feat: Agent kils itself after updating a device

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -543,6 +543,9 @@ int main(int argc, char *argv[]) {
 				}
 				printf("Device verified, about to update\n");
 				apply_ota(ssl);
+
+				printf("Update ended, raising ^C to myself\n");
+				kill(getpid(), SIGINT);
 			} else {
 				printf("Not verified device\n");
 				int ret = notify_auth_failure(ssl);


### PR DESCRIPTION
Since there's already a routine for handling
the `SIGINT` signal (performs cleanup before
ending), we raise that signal manually using
`kill()` after finishing with the update.